### PR TITLE
Tinha um bug quando o valor do produto era menor que 1 e maior que 0

### DIFF
--- a/lib/pagseguro/notification.rb
+++ b/lib/pagseguro/notification.rb
@@ -167,6 +167,7 @@ module PagSeguro
 
     # Convert amount format to float
     def to_price(amount)
+      amount = "0#{amount}" if amount =~ /^\,/
       amount.to_s.gsub(/[^\d]/, "").gsub(/^(\d+)(\d{2})$/, '\1.\2').to_f
     end
 

--- a/spec/pagseguro/notification_spec.rb
+++ b/spec/pagseguro/notification_spec.rb
@@ -203,6 +203,26 @@ describe PagSeguro::Notification do
       p[:fees].should == 2.53
       p[:shipping].should == 3.50
     end
+    
+    specify "bug fix: should work correctly when price is 0.9" do
+      set_product!({
+        :description => "Rails Application Templates",
+        :price => ",90",
+        :id => 8,
+        :fees => "2,53",
+        :shipping => "3,50",
+        :quantity => 10
+      })
+
+      p = @notification.products.first
+
+      p[:description].should == "Rails Application Templates"
+      p[:price].should == 0.9
+      p[:id].should == "8"
+      p[:quantity].should == 10
+      p[:fees].should == 2.53
+      p[:shipping].should == 3.50
+    end
   end
 
   describe "confirmation" do


### PR DESCRIPTION
Por exemplo: 0.9 virava 90.0 no retorno do PagSeguro.
