### PR TITLE
Fix the Form URL

### DIFF
--- a/lib/pagseguro/base.rb
+++ b/lib/pagseguro/base.rb
@@ -3,7 +3,7 @@ module PagSeguro
 
   # PagSeguro receives all invoices in this URL. If developer mode is enabled,
   # then the URL will be /pagseguro_developer/invoice
-  GATEWAY_URL = "https://pagseguro.uol.com.br/pagseguro-ws/checkout/NPI.jhtml"
+  GATEWAY_URL = "https://pagseguro.uol.com.br/checkout/checkout.jhtml"
 
   # Hold the config/pagseguro.yml contents
   @@config = nil

--- a/spec/pagseguro/pagseguro_spec.rb
+++ b/spec/pagseguro/pagseguro_spec.rb
@@ -34,7 +34,7 @@ describe PagSeguro do
 
     it "should return real url if developer mode is disabled" do
       PagSeguro.should_receive(:developer?).and_return(false)
-      PagSeguro.gateway_url.should == "https://pagseguro.uol.com.br/pagseguro-ws/checkout/NPI.jhtml"
+      PagSeguro.gateway_url.should == "https://pagseguro.uol.com.br/checkout/checkout.jhtml"
     end
 
     it "should read configuration developer mode" do

--- a/spec/support/config/boot.rb
+++ b/spec/support/config/boot.rb
@@ -1,4 +1,4 @@
-ENV["BUNDLE_GEMFILE"] = File.dirname(__FILE__) + "/../../../../Gemfile"
+ENV["BUNDLE_GEMFILE"] = File.dirname(__FILE__) + "/../../../Gemfile"
 require "bundler"
 Bundler.setup
 require "rails/all"


### PR DESCRIPTION
Conforme especificado no ticket #21, o endereço do form está errado. Este patch arruma isto. Depois do merge, o ticket #21 pode ser encerrado.
# O que foi feito

O spec da URL foi atualizado também.

Além disto, em support/config/boot.rb, o endereço continha um ../ a mais. Ele estava procurando o Gemfile fora do diretório da gem.

Sinceramente, não sei como você estava conseguindo testar a gem com esse bug. Também não sei como essa gem está sendo usada por aí afora com a URL do formulário quebrada.

É isto. Valeu.
